### PR TITLE
Introduce randomization of the tick interval

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ package main
 import (
 	"fmt"
 	"log/syslog"
+	"math/rand"
 	"os"
 	"os/signal"
 	"time"
@@ -138,9 +139,13 @@ func main() {
 		for {
 			select {
 			case <-ticker.C:
+				ticker.Stop()
 				for _, hca := range hcas {
 					hca.NetDiscover(splitter)
 				}
+				intvl := int64(time.Duration(conf.PollInterval))
+				r := rand.Int63n(intvl/5) - intvl/10
+				ticker = time.NewTicker(time.Duration(conf.PollInterval) + time.Duration(r))
 			case <-shutdownChan:
 				log.Debug("Shutdown received in polling loop.")
 				break Loop


### PR DESCRIPTION
As we are potentially uploading the data from multiple agents to a single database instance, it may be a good idea to randomly spread the requests over time.

On each poll, re-create the ticker with slightly changed period.
Period is modified by a random value within +/- 10%.

Signed-off-by: Eugene Crosser <evgenii.cherkashin@profitbricks.com>